### PR TITLE
feat: add prestashop routes

### DIFF
--- a/src/Http/Controllers/CredentialController.php
+++ b/src/Http/Controllers/CredentialController.php
@@ -35,7 +35,7 @@ class CredentialController extends Controller
 
         $apiVersion = (new ShoifyApiVersion)->getApiVersion();
 
-        return view('shopify::credential.index', compact('apiVersion'));
+        return view('prestashop::credential.index', compact('apiVersion'));
     }
 
     /**
@@ -91,7 +91,7 @@ class CredentialController extends Controller
         }
 
         return new JsonResponse([
-            'redirect_url' => route('shopify.credentials.edit', $credentialCreate->id),
+            'redirect_url' => route('prestashop.credentials.edit', $credentialCreate->id),
         ]);
     }
 
@@ -138,7 +138,7 @@ class CredentialController extends Controller
 
         $credential->accessToken = str_repeat('*', strlen($credential->accessToken));
 
-        return view('shopify::credential.edit', compact('credential', 'shopLocales', 'publishingChannel', 'locationAll', 'apiVersion'));
+        return view('prestashop::credential.edit', compact('credential', 'shopLocales', 'publishingChannel', 'locationAll', 'apiVersion'));
     }
 
     /**
@@ -169,7 +169,7 @@ class CredentialController extends Controller
         $response = $this->requestPrestashopApiAction('products', $requestData);
 
         if ($response['code'] != 200) {
-            return redirect()->route('shopify.credentials.edit', $id)
+            return redirect()->route('prestashop.credentials.edit', $id)
                 ->withErrors([
                     'shopUrl'     => trans('shopify::app.shopify.credential.invalid'),
                     'accessToken' => trans('shopify::app.shopify.credential.invalid'),
@@ -210,6 +210,6 @@ class CredentialController extends Controller
 
         session()->flash('success', trans('shopify::app.shopify.credential.update-success'));
 
-        return redirect()->route('shopify.credentials.edit', $id);
+        return redirect()->route('prestashop.credentials.edit', $id);
     }
 }

--- a/src/Http/Controllers/ImportMappingController.php
+++ b/src/Http/Controllers/ImportMappingController.php
@@ -45,7 +45,7 @@ class ImportMappingController extends Controller
             $mediaMapping[$row] = $value;
         }
 
-        return view('shopify::import.mapping.index', compact('mappingFields', 'formattedShopifyMapping', 'shopifyMapping', 'shopifyCredentials', 'mediaMapping'));
+        return view('prestashop::import.mapping.index', compact('mappingFields', 'formattedShopifyMapping', 'shopifyMapping', 'shopifyCredentials', 'mediaMapping'));
     }
 
     /**
@@ -68,7 +68,7 @@ class ImportMappingController extends Controller
 
             $keysAsArray = array_fill_keys($duplicateKeys, 'Duplicate attribute mapping');
 
-            return redirect()->route('admin.shopify.import-mappings', 3)
+            return redirect()->route('admin.prestashop.import-mappings', 3)
                 ->withErrors($keysAsArray)
                 ->withInput();
         }
@@ -87,7 +87,7 @@ class ImportMappingController extends Controller
 
         session()->flash('success', trans('shopify::app.shopify.import.mapping.created'));
 
-        return redirect()->route('admin.shopify.import-mappings', 3);
+        return redirect()->route('admin.prestashop.import-mappings', 3);
     }
 
     public function formatMediaMapping(array &$filteredData, array &$mappingFields)

--- a/src/Http/Controllers/MappingController.php
+++ b/src/Http/Controllers/MappingController.php
@@ -57,7 +57,7 @@ class MappingController extends Controller
             $mediaMapping[$row] = $value;
         }
 
-        return view('shopify::export.mapping.index', compact('mappingFields', 'formattedShopifyMapping', 'shopifyDefaultMapping', 'formattedOtherMapping', 'shopifyMapping', 'mediaMapping', 'metaFieldTypeInShopify'));
+        return view('prestashop::export.mapping.index', compact('mappingFields', 'formattedShopifyMapping', 'shopifyDefaultMapping', 'formattedOtherMapping', 'shopifyMapping', 'mediaMapping', 'metaFieldTypeInShopify'));
     }
 
     /**
@@ -99,7 +99,7 @@ class MappingController extends Controller
 
         session()->flash('success', trans('shopify::app.shopify.export.mapping.created'));
 
-        return redirect()->route('admin.shopify.export-mappings', 1);
+        return redirect()->route('admin.prestashop.export-mappings', 1);
     }
 
     public function formatMediaMapping(array &$filteredData, array &$mappingFields)

--- a/src/Http/Controllers/MetaFieldController.php
+++ b/src/Http/Controllers/MetaFieldController.php
@@ -71,7 +71,7 @@ class MetaFieldController extends Controller
         $metaFieldType = $object->getMetaFieldType();
         $metaFieldTypeInShopify = $object->getMetaFieldTypeInShopify();
 
-        return view('shopify::metafield.index', compact('metaFieldType', 'metaFieldTypeInShopify'));
+        return view('prestashop::metafield.index', compact('metaFieldType', 'metaFieldTypeInShopify'));
     }
 
     /**
@@ -168,7 +168,7 @@ class MetaFieldController extends Controller
         }
 
         return new JsonResponse([
-            'redirect_url' => route('shopify.metafield.edit', $metaFieldCreate->id),
+            'redirect_url' => route('prestashop.metafield.edit', $metaFieldCreate->id),
         ]);
     }
 
@@ -274,7 +274,7 @@ class MetaFieldController extends Controller
         $metaFieldType = $object->getMetaFieldType();
         $metaFieldTypeInShopify = $object->getMetaFieldTypeInShopify();
 
-        return view('shopify::metafield.edit', compact('metaField', 'metaFieldType', 'metaFieldTypeInShopify'));
+        return view('prestashop::metafield.edit', compact('metaField', 'metaFieldType', 'metaFieldTypeInShopify'));
     }
 
     /**
@@ -350,7 +350,7 @@ class MetaFieldController extends Controller
         }
 
         if (! empty($errors)) {
-            return redirect()->route('shopify.metafield.edit', $id)
+            return redirect()->route('prestashop.metafield.edit', $id)
                 ->withErrors($errors)
                 ->withInput();
         }
@@ -358,7 +358,7 @@ class MetaFieldController extends Controller
         $this->shopifyMetaFieldRepository->update($requestData, $id);
         session()->flash('success', trans('shopify::app.shopify.metafield.update-success'));
 
-        return redirect()->route('shopify.metafield.edit', $id);
+        return redirect()->route('prestashop.metafield.edit', $id);
     }
 
     /**

--- a/src/Http/Controllers/SettingController.php
+++ b/src/Http/Controllers/SettingController.php
@@ -25,7 +25,7 @@ class SettingController extends Controller
     {
         $shopifySettings = $this->shopifyExportMappingRepository->find(2);
 
-        return view('shopify::export.settings.index', compact('shopifySettings'));
+        return view('prestashop::export.settings.index', compact('shopifySettings'));
     }
 
     /**
@@ -53,6 +53,6 @@ class SettingController extends Controller
 
         session()->flash('success', trans('shopify::app.shopify.export.settings.created'));
 
-        return redirect()->route('admin.shopify.settings', 2);
+        return redirect()->route('admin.prestashop.settings', 2);
     }
 }

--- a/src/Routes/prestashop-routes.php
+++ b/src/Routes/prestashop-routes.php
@@ -12,79 +12,79 @@ use Webkul\Prestashop\Http\Controllers\SettingController;
  * Catalog routes.
  */
 Route::group(['middleware' => ['admin'], 'prefix' => config('app.admin_url')], function () {
-    Route::prefix('shopify')->group(function () {
+    Route::prefix('prestashop')->group(function () {
 
         Route::controller(CredentialController::class)->prefix('credentials')->group(function () {
-            Route::get('', 'index')->name('shopify.credentials.index');
+            Route::get('', 'index')->name('prestashop.credentials.index');
 
-            Route::post('create', 'store')->name('shopify.credentials.store');
+            Route::post('create', 'store')->name('prestashop.credentials.store');
 
-            Route::get('edit/{id}', 'edit')->name('shopify.credentials.edit');
+            Route::get('edit/{id}', 'edit')->name('prestashop.credentials.edit');
 
-            Route::put('update/{id}', 'update')->name('shopify.credentials.update');
+            Route::put('update/{id}', 'update')->name('prestashop.credentials.update');
 
-            Route::delete('delete/{id}', 'destroy')->name('shopify.credentials.delete');
+            Route::delete('delete/{id}', 'destroy')->name('prestashop.credentials.delete');
         });
 
         Route::controller(MetaFieldController::class)->prefix('metafields')->group(function () {
-            Route::get('', 'index')->name('shopify.metafield.index');
+            Route::get('', 'index')->name('prestashop.metafield.index');
 
-            Route::post('create', 'store')->name('shopify.metafield.store');
+            Route::post('create', 'store')->name('prestashop.metafield.store');
 
-            Route::get('edit/{id}', 'edit')->name('shopify.metafield.edit');
+            Route::get('edit/{id}', 'edit')->name('prestashop.metafield.edit');
 
-            Route::put('update/{id}', 'update')->name('shopify.metafield.update');
+            Route::put('update/{id}', 'update')->name('prestashop.metafield.update');
 
-            Route::delete('delete/{id}', 'destroy')->name('shopify.metafield.delete');
+            Route::delete('delete/{id}', 'destroy')->name('prestashop.metafield.delete');
 
-            Route::post('mass-delete', 'massDestroy')->name('shopify.metafield.mass_delete');
+            Route::post('mass-delete', 'massDestroy')->name('prestashop.metafield.mass_delete');
         });
 
         Route::prefix('export')->group(function () {
             Route::controller(SettingController::class)->prefix('settings')->group(function () {
-                Route::get('{id}', 'index')->name('admin.shopify.settings');
+                Route::get('{id}', 'index')->name('admin.prestashop.settings');
 
-                Route::post('create', 'store')->name('shopify.export-settings.create');
+                Route::post('create', 'store')->name('prestashop.export-settings.create');
             });
             Route::controller(MappingController::class)->prefix('mapping')->group(function () {
-                Route::get('{id}', 'index')->name('admin.shopify.export-mappings');
+                Route::get('{id}', 'index')->name('admin.prestashop.export-mappings');
 
-                Route::post('create', 'store')->name('shopify.export-mappings.create');
+                Route::post('create', 'store')->name('prestashop.export-mappings.create');
             });
 
         });
 
         Route::prefix('import')->group(function () {
             Route::controller(ImportMappingController::class)->prefix('mapping')->group(function () {
-                Route::get('{id}', 'index')->name('admin.shopify.import-mappings');
+                Route::get('{id}', 'index')->name('admin.prestashop.import-mappings');
 
-                Route::post('create', 'store')->name('shopify.import-mappings.create');
+                Route::post('create', 'store')->name('prestashop.import-mappings.create');
             });
         });
 
         Route::controller(OptionController::class)->group(function () {
 
-            Route::get('get-attribute', 'listAttributes')->name('admin.shopify.get-attribute');
+            Route::get('get-attribute', 'listAttributes')->name('admin.prestashop.get-attribute');
 
-            Route::get('get-image-attribute', 'listImageAttributes')->name('admin.shopify.get-image-attribute');
+            Route::get('get-image-attribute', 'listImageAttributes')->name('admin.prestashop.get-image-attribute');
 
-            Route::get('get-gallery-attribute', 'listGalleryAttributes')->name('admin.shopify.get-gallery-attribute');
+            Route::get('get-gallery-attribute', 'listGalleryAttributes')->name('admin.prestashop.get-gallery-attribute');
 
-            Route::get('get-metafield-attribute', 'listMetafieldAttributes')->name('admin.shopify.get-metafield-attribute');
+            Route::get('get-metafield-attribute', 'listMetafieldAttributes')->name('admin.prestashop.get-metafield-attribute');
 
-            Route::get('selected-metafield-attribute', 'selectedMetafieldAttributes')->name('admin.shopify.get-selected-attribute');
+            Route::get('selected-metafield-attribute', 'selectedMetafieldAttributes')->name('admin.prestashop.get-selected-attribute');
 
-            Route::get('get-shopify-credentials', 'listShopifyCredential')->name('shopify.credential.fetch-all');
+            Route::get('get-prestashop-credentials', 'listShopifyCredential')->name('prestashop.credential.fetch-all');
 
-            Route::get('get-shopify-channel', 'listChannel')->name('shopify.channel.fetch-all');
+            Route::get('get-prestashop-channel', 'listChannel')->name('prestashop.channel.fetch-all');
 
-            Route::get('get-shopify-currency', 'listCurrency')->name('shopify.currency.fetch-all');
+            Route::get('get-prestashop-currency', 'listCurrency')->name('prestashop.currency.fetch-all');
 
-            Route::get('get-shopify-locale', 'listLocale')->name('shopify.locale.fetch-all');
+            Route::get('get-prestashop-locale', 'listLocale')->name('prestashop.locale.fetch-all');
 
-            Route::get('get-shopify-attrGroup', 'listAttributeGroup')->name('shopify.attribute-group.fetch-all');
+            Route::get('get-prestashop-attrGroup', 'listAttributeGroup')->name('prestashop.attribute-group.fetch-all');
 
-            Route::get('get-shopify-family', 'listShopifyFamily')->name('admin.shopify.get-all-family-variants');
+            Route::get('get-prestashop-family', 'listShopifyFamily')->name('admin.prestashop.get-all-family-variants');
         });
 
     });


### PR DESCRIPTION
## Summary
- add Prestashop-specific routes
- update controllers to render Prestashop views and routes

## Testing
- `php -l src/Routes/prestashop-routes.php`
- `php -l src/Http/Controllers/CredentialController.php`
- `php -l src/Http/Controllers/MetaFieldController.php`
- `php -l src/Http/Controllers/MappingController.php`
- `php -l src/Http/Controllers/ImportMappingController.php`
- `php -l src/Http/Controllers/SettingController.php`


------
https://chatgpt.com/codex/tasks/task_e_689091ac993c8330bd4889b32adc50ad